### PR TITLE
FileUtility - Checks if destination folder exists, then creates one if it doesn't

### DIFF
--- a/UnityBuild-FileUtility/Editor/FolderOperation.cs
+++ b/UnityBuild-FileUtility/Editor/FolderOperation.cs
@@ -82,6 +82,11 @@ public class FolderOperation : BuildAction, IPreBuildAction, IPreBuildPerPlatfor
             errorString = "Input does not exist.";
         }
 
+        if (!Directory.Exists(outputPath))
+        {
+            Directory.CreateDirectory(outputPath);
+        }
+
         if (overwrite && Directory.Exists(outputPath))
         {
             // Delete previous output.
@@ -112,6 +117,11 @@ public class FolderOperation : BuildAction, IPreBuildAction, IPreBuildPerPlatfor
             // Error. Input does not exist.
             success = false;
             errorString = "Input does not exist.";
+        }
+
+        if (!Directory.Exists(outputPath))
+        {
+            Directory.CreateDirectory(outputPath);
         }
 
         if (success && overwrite && Directory.Exists(outputPath))


### PR DESCRIPTION
Unity would throw an IO exception if I tried to copy my $BUILDPATH to another folder if the destination had a path like: C:/path to my google drive/game builds/$PRODUCT_NAME-$VERSION/$ARCHITECTURE. Builds would work as expected without the nested folder.

Adding a check that the folder exists before trying the copy, and creating it if it doesn't, prevents the exception for me and made the build action work as I expected, so I thought I would share.