### PR TITLE
ZipFile - Is not using output directory

### DIFF
--- a/UnityBuild-ZipFile/Editor/ZipFileOperation.cs
+++ b/UnityBuild-ZipFile/Editor/ZipFileOperation.cs
@@ -1,5 +1,7 @@
 ﻿using Ionic.Zip;
 using System.IO;
+using UnityEditor;
+using UnityEngine;
 
 namespace SuperSystems.UnityBuild
 {


### PR DESCRIPTION
Zip File wasn't using the output directory I specified.

Then when I made changes, similarly to my other pull request with the folder utility, Unity would throw an IO exception if I tried to create the zip with a path like: C:/some folders/game builds/$PRODUCT_NAME-$VERSION/$ARCHITECTURE.zip

My changes seem to make the build action work as I expected it to.