### PR TITLE
Add option to append release type to itch channel.

### DIFF
--- a/UnityBuild-ItchUploader/Editor/UploadItch.cs
+++ b/UnityBuild-ItchUploader/Editor/UploadItch.cs
@@ -25,7 +25,7 @@ public class UploadItch : BuildAction, IPostBuildPerPlatformAction
     [Header("Use with caution. Override applies to all platforms.")]
     public string itchChannelOverride = "";
 
-    public bool addReleaseToChannel = false;
+    public bool addReleaseTypeToChannel = false;
 
     #region Public Methods
 
@@ -75,10 +75,10 @@ public class UploadItch : BuildAction, IPostBuildPerPlatformAction
         else
         {
             string itchChannel = GetChannelName(architecture.target);
-            if (addReleaseToChannel && !string.IsNullOrEmpty(releaseType.typeName)) {
+            if (addReleaseTypeToChannel && !string.IsNullOrEmpty(releaseType.typeName)) {
                 itchChannel += "-" + releaseType.typeName.ToLower().Replace(' ', '-');
             }
-            
+
             if(string.IsNullOrEmpty(itchChannel))
             {
                 UnityEngine.Debug.LogWarning("UploadItch: The current BuildTarget doesn't appear to be a standard Itch.IO build target.");

--- a/UnityBuild-ItchUploader/Editor/UploadItch.cs
+++ b/UnityBuild-ItchUploader/Editor/UploadItch.cs
@@ -16,7 +16,7 @@ public class UploadItch : BuildAction, IPostBuildPerPlatformAction
     [FilePath(false, true, "Path to butler.exe")]
     public string pathToButlerExe = "";
     public string nameOfItchUser = "";
-    public string nameOfItchGame = ""; 
+    public string nameOfItchGame = "";
     public bool useGeneratedBuildVersion = false;
 
     [Header("Disable to capture error output for debugging.")]
@@ -24,6 +24,8 @@ public class UploadItch : BuildAction, IPostBuildPerPlatformAction
 
     [Header("Use with caution. Override applies to all platforms.")]
     public string itchChannelOverride = "";
+
+    public bool addReleaseToChannel = false;
 
     #region Public Methods
 
@@ -73,6 +75,10 @@ public class UploadItch : BuildAction, IPostBuildPerPlatformAction
         else
         {
             string itchChannel = GetChannelName(architecture.target);
+            if (addReleaseToChannel && !string.IsNullOrEmpty(releaseType.typeName)) {
+                itchChannel += "-" + releaseType.typeName.ToLower().Replace(' ', '-');
+            }
+            
             if(string.IsNullOrEmpty(itchChannel))
             {
                 UnityEngine.Debug.LogWarning("UploadItch: The current BuildTarget doesn't appear to be a standard Itch.IO build target.");
@@ -171,7 +177,7 @@ public class UploadItch : BuildAction, IPostBuildPerPlatformAction
             case BuildTarget.StandaloneOSXUniversal:
                 return OSX + "-universal";
 #endif
-            
+
             default:
                 return null;
         }


### PR DESCRIPTION
This is mainly because I like to do post game jam updates to my game while preserving the final jam version.  

So for example: I have a Jam Final and Post Jam release type, so now I can append those to my channel so that I can have both versions per platform available.  This would generate my-game-windows-x64-jam-final and my-game-windows-x64-post-jam respectively.