### PR TITLE
XR Settings build action

### DIFF
--- a/UnityBuild-XRSettings.meta
+++ b/UnityBuild-XRSettings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a5209becd02e09d48a85b9802cad3daf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityBuild-XRSettings/Editor.meta
+++ b/UnityBuild-XRSettings/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 594ad643f17f3db4cb2a8c8d26184fb9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityBuild-XRSettings/Editor/XRSettings.cs
+++ b/UnityBuild-XRSettings/Editor/XRSettings.cs
@@ -1,3 +1,7 @@
+#if UNITY_2017_4 || UNITY_2018_4 || UNITY_2019_2_OR_NEWER
+#define SUPPORTS_OCULUS_V2_SIGNING
+#endif
+
 using System;
 using System.Collections.Generic;
 using UnityEditor;
@@ -38,8 +42,14 @@ namespace SuperSystems.UnityBuild
         [Tooltip("Stereo rendering mode to use")]
         public StereoRenderingPath StereoRenderingMode;
 
+#if SUPPORTS_OCULUS_V2_SIGNING
+        [Header("SDK-Specific Settings")]
+        [Tooltip("Oculus: Whether or not to use v2 APK signing (enable for Quest, disable for Gear VR/Go)")]
+        public bool OculusV2Signing = true;
+#endif
+
         [Header("Platform-Specific Settings")]
-        [Tooltip("Whether or not build target supports ARCore (Android only)")]
+        [Tooltip("Android: Whether or not build target supports ARCore")]
         public bool ARCoreSupported;
 
         public override void PerBuildExecute(BuildReleaseType releaseType, BuildPlatform platform, BuildArchitecture architecture, BuildDistribution distribution, System.DateTime buildTime, ref BuildOptions options, string configKey, string buildPath)
@@ -64,6 +74,10 @@ namespace SuperSystems.UnityBuild
             PlayerSettings.SetVirtualRealitySupported(platform.targetGroup, VRSupported);
             PlayerSettings.SetVirtualRealitySDKs(platform.targetGroup, sdks.ToArray());
             PlayerSettings.stereoRenderingPath = StereoRenderingMode;
+
+#if SUPPORTS_OCULUS_V2_SIGNING
+            PlayerSettings.VROculus.v2Signing = OculusV2Signing;
+#endif
 
             if (platform.targetGroup == BuildTargetGroup.Android)
             {

--- a/UnityBuild-XRSettings/Editor/XRSettings.cs
+++ b/UnityBuild-XRSettings/Editor/XRSettings.cs
@@ -35,6 +35,8 @@ namespace SuperSystems.UnityBuild
         public List<SDK> Sdks = new List<SDK>();
         [Tooltip("Whether or not build target supports VR")]
         public bool VRSupported;
+        [Tooltip("Stereo rendering mode to use")]
+        public StereoRenderingPath StereoRenderingMode;
 
         [Header("Platform-Specific Settings")]
         [Tooltip("Whether or not build target supports ARCore (Android only)")]
@@ -61,6 +63,7 @@ namespace SuperSystems.UnityBuild
             // Update player settings
             PlayerSettings.SetVirtualRealitySupported(platform.targetGroup, VRSupported);
             PlayerSettings.SetVirtualRealitySDKs(platform.targetGroup, sdks.ToArray());
+            PlayerSettings.stereoRenderingPath = StereoRenderingMode;
 
             if (platform.targetGroup == BuildTargetGroup.Android)
             {
@@ -68,5 +71,4 @@ namespace SuperSystems.UnityBuild
             }
         }
     }
-
 }

--- a/UnityBuild-XRSettings/Editor/XRSettings.cs
+++ b/UnityBuild-XRSettings/Editor/XRSettings.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace SuperSystems.UnityBuild
+{
+    public class XRSettings : BuildAction, IPreBuildPerPlatformAction
+    {
+        public enum SDK
+        {
+            None,
+            Cardboard,
+            Daydream,
+            MockHMD,
+            Oculus,
+            OpenVR,
+            StereoDisplay,
+        }
+
+        // Mapping of SDKs enum to Unity's inconsistent internal names
+        readonly Dictionary<SDK, string> sdkNames = new Dictionary<SDK, string>()
+        {
+            {SDK.None, "None"},
+            {SDK.Cardboard, "cardboard"},
+            {SDK.Daydream, "daydream"},
+            {SDK.MockHMD, "MockHMD"},
+            {SDK.Oculus, "Oculus"},
+            {SDK.OpenVR, "OpenVR"},
+            {SDK.StereoDisplay, "stereo"}
+        };
+
+        [Header("XR Settings")]
+        [Tooltip("VR SDKs for build target, in order of priority")]
+        public List<SDK> Sdks = new List<SDK>();
+        [Tooltip("Whether or not build target supports VR")]
+        public bool VRSupported;
+
+        [Header("Platform-Specific Settings")]
+        [Tooltip("Whether or not build target supports ARCore (Android only)")]
+        public bool ARCoreSupported;
+
+        public override void PerBuildExecute(BuildReleaseType releaseType, BuildPlatform platform, BuildArchitecture architecture, BuildDistribution distribution, System.DateTime buildTime, ref BuildOptions options, string configKey, string buildPath)
+        {
+            // Get valid SDKs for platform
+            string[] validSDKs = PlayerSettings.GetAvailableVirtualRealitySDKs(platform.targetGroup);
+
+            // Build list of valid SDKs to set
+            List<string> sdks = new List<string>();
+
+            foreach (SDK sdk in Sdks)
+            {
+                string sdkName = sdkNames[sdk];
+
+                if (Array.IndexOf(validSDKs, sdkName) != -1)
+                {
+                    sdks.Add(sdkName);
+                }
+            }
+
+            // Update player settings
+            PlayerSettings.SetVirtualRealitySupported(platform.targetGroup, VRSupported);
+            PlayerSettings.SetVirtualRealitySDKs(platform.targetGroup, sdks.ToArray());
+
+            if (platform.targetGroup == BuildTargetGroup.Android)
+            {
+                PlayerSettings.Android.ARCoreEnabled = ARCoreSupported;
+            }
+        }
+    }
+
+}

--- a/UnityBuild-XRSettings/Editor/XRSettings.cs
+++ b/UnityBuild-XRSettings/Editor/XRSettings.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace SuperSystems.UnityBuild
 {
-    public class XRSettings : BuildAction, IPreBuildPerPlatformAction
+    public class XRSettings : BuildAction, IPreBuildPerPlatformAction, IPostBuildPerPlatformAction
     {
         public enum SDK
         {

--- a/UnityBuild-XRSettings/Editor/XRSettings.cs.meta
+++ b/UnityBuild-XRSettings/Editor/XRSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9895d1b92e2dd6a41b67909ee897d770
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityBuild-XRSettings/README.md
+++ b/UnityBuild-XRSettings/README.md
@@ -1,0 +1,2 @@
+# SuperUnityBuild - XR Settings
+> Modify player XR settings

--- a/UnityBuild-XRSettings/README.md.meta
+++ b/UnityBuild-XRSettings/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e406c2ed22747424ca6f2682096c9598
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This build action enables updating player XR Settings when running a build:

- Set VR SDKs
- Set VR support
- Set ARCore support (Android only)

Using the filter system, it is possible to use this action to update these settings on a per-Release Type basis.