### PR TITLE
Add $BASEPATH to File and Folder path substitutions.

### DIFF
--- a/UnityBuild-FileUtility/Editor/FileOperation.cs
+++ b/UnityBuild-FileUtility/Editor/FileOperation.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using UnityEditor;
+using System;
 using System.Collections;
 using System.IO;
 
@@ -42,8 +43,8 @@ public class FileOperation : BuildAction, IPreBuildAction, IPreBuildPerPlatformA
 
     public override void PerBuildExecute(BuildReleaseType releaseType, BuildPlatform platform, BuildArchitecture architecture, BuildDistribution distribution, System.DateTime buildTime, ref BuildOptions options, string configKey, string buildPath)
     {
-        string resolvedInputPath = BuildProject.ResolvePath(inputPath.Replace("$BUILDPATH", buildPath), releaseType, platform, architecture, distribution, buildTime);
-        string resolvedOutputPath = BuildProject.ResolvePath(outputPath.Replace("$BUILDPATH", buildPath), releaseType, platform, architecture, distribution, buildTime);
+        string resolvedInputPath = FolderOperation.ResolvePath(inputPath, releaseType, platform, architecture, distribution, buildTime, buildPath);
+        string resolvedOutputPath = FolderOperation.ResolvePath(outputPath, releaseType, platform, architecture, distribution, buildTime, buildPath);
 
         switch (operation)
         {


### PR DESCRIPTION
Add $BASEPATH to substitutions in paths for File and Folder actions. Plus some extra error handling, which got added in while debugging.

Rationale: if $BUILDPATH includes $VERSION, you can create a copy of what will always be the latest build somewhere under your base path without having to repeat the literal value from Basic Settings.

Did this entirely for my own convenience, just throwing it back in case it makes sense to anyone else.