### PR TITLE
XR Plug-in Management build action

### DIFF
--- a/UnityBuild-XRPluginManagement.meta
+++ b/UnityBuild-XRPluginManagement.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 214b6ce806feef54fb9f62d13a2c0da4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityBuild-XRPluginManagement/Editor.meta
+++ b/UnityBuild-XRPluginManagement/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1f1dc6292a6d21244be65d0545041b64
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityBuild-XRPluginManagement/Editor/XRPluginManagement.cs
+++ b/UnityBuild-XRPluginManagement/Editor/XRPluginManagement.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.XR.Management;
+using UnityEngine;
+using UnityEngine.XR.Management;
+
+namespace SuperSystems.UnityBuild
+{
+    public class XRPluginManagement : BuildAction, IPreBuildAction, IPreBuildPerPlatformAction
+    {
+        [Header("XR Settings")]
+        [Tooltip("XR plugin loaders to use for this build")] public List<XRLoader> XRPlugins = new List<XRLoader>();
+        [Tooltip("Whether or not to use automatic initialization of XR plugin loaders on startup")] public bool InitializeXROnStartup = true;
+
+        public override void PerBuildExecute(BuildReleaseType releaseType, BuildPlatform platform, BuildArchitecture architecture, BuildDistribution distribution, DateTime buildTime, ref BuildOptions options, string configKey, string buildPath)
+        {
+            XRGeneralSettings generalSettings = XRGeneralSettingsPerBuildTarget.XRGeneralSettingsForBuildTarget(platform.targetGroup);
+            XRManagerSettings settingsManager = generalSettings.Manager;
+            List<XRLoader> previousLoaders = settingsManager.loaders;
+
+            generalSettings.InitManagerOnStart = InitializeXROnStartup;
+
+            settingsManager.loaders = XRPlugins;
+        }
+    }
+}

--- a/UnityBuild-XRPluginManagement/Editor/XRPluginManagement.cs.meta
+++ b/UnityBuild-XRPluginManagement/Editor/XRPluginManagement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c5527d4e3b8c134c885a687264c8024
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityBuild-XRPluginManagement/README.md
+++ b/UnityBuild-XRPluginManagement/README.md
@@ -1,0 +1,2 @@
+# SuperUnityBuild - XR Plug-in Management
+> Enable per-build [Unity XR Plug-in Management](https://docs.unity3d.com/Packages/com.unity.xr.management@latest) settings

--- a/UnityBuild-XRPluginManagement/README.md.meta
+++ b/UnityBuild-XRPluginManagement/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cb9abcce9505d194cbf5bde48d482cf4
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This build action enables configuring Unity [XR Plug-in Management](https://docs.unity3d.com/Packages/com.unity.xr.management@latest) settings when running a build:

- Set XR Plugin loaders
- Set XR Management auto-initialization

Using the filter system, it is possible to use this action to update these settings on a per-Release Type basis.

Along with my previous build action for configuring the legacy XR system settings (#13), this could close Chaser324/unity-build#30