### PR TITLE
Package Management build action

### DIFF
--- a/UnityBuild-PackageManagement.meta
+++ b/UnityBuild-PackageManagement.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4cf3c3c70cfb5ca41af17d956cb58c5d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityBuild-PackageManagement/Editor.meta
+++ b/UnityBuild-PackageManagement/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 968e595265f54ae4fb71a48da5819f9b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityBuild-PackageManagement/Editor/PackageManagement.cs
+++ b/UnityBuild-PackageManagement/Editor/PackageManagement.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.PackageManager;
+using UnityEditor.PackageManager.Requests;
+using UnityEngine;
+
+namespace SuperSystems.UnityBuild
+{
+    public class PackageManagement : BuildAction, IPreBuildAction, IPreBuildPerPlatformAction, IPostBuildAction, IPostBuildPerPlatformAction
+    {
+        [Header("Package Settings")]
+        [Tooltip("List of package IDs to add")] public List<string> PackagesToAdd = new List<string>();
+        [Tooltip("List of package IDs to remove")] public List<string> PackagesToRemove = new List<string>();
+
+        public override void PerBuildExecute(BuildReleaseType releaseType, BuildPlatform platform, BuildArchitecture architecture, BuildDistribution distribution, DateTime buildTime, ref BuildOptions options, string configKey, string buildPath)
+        {
+
+            PackagesToRemove.ForEach(id => HandleRequest(Client.Remove(id), id));
+            PackagesToAdd.ForEach(id => HandleRequest(Client.Add(id), id));
+        }
+
+        private void HandleRequest<T>(T request, string id) where T : Request
+        {
+            // Block until complete
+            while (!request.IsCompleted) { }
+
+            switch (request.Status)
+            {
+                case StatusCode.Success:
+                    Debug.Log($"Package request succeeded for {id}");
+                    break;
+
+                case StatusCode.Failure:
+                    Debug.LogError($"Package request failed for {id}: {request.Error}");
+                    break;
+
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/UnityBuild-PackageManagement/Editor/PackageManagement.cs.meta
+++ b/UnityBuild-PackageManagement/Editor/PackageManagement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 535ef7a1e07040d4cb91a930cca5a355
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityBuild-PackageManagement/README.md
+++ b/UnityBuild-PackageManagement/README.md
@@ -1,0 +1,2 @@
+# SuperUnityBuild - Package Management
+> Enable per-build Unity Package Manager settings

--- a/UnityBuild-PackageManagement/README.md.meta
+++ b/UnityBuild-PackageManagement/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 55a91ac8b6f30814c8d8ab448f03fd87
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This build action enables adding or removing Unity Package Management packages when running a build, which is useful if you want to prevent a package from including a native plugin in a particular release type (e.g. removing Steam VR from an Oculus-only release type).

Using the filter system, it is possible to use this action to update these settings on a per-Release Type basis.