### PR TITLE
Fix for ZIP File Creation on MacOS Using System.IO.Compression

### DIFF
--- a/Editor/ZipFile/ZipFileOperation.cs
+++ b/Editor/ZipFile/ZipFileOperation.cs
@@ -1,12 +1,16 @@
-﻿using Ionic.Zip;
-using SuperUnityBuild.BuildTool;
+﻿using SuperUnityBuild.BuildTool;
 using System;
 using System.IO;
-using UnityEngine;
+#if NET_4_6 || NETSTANDARD2_0_OR_GREATER
+using System.IO.Compression;
+#else
+using Ionic.Zip;
+#endif
 
 namespace SuperUnityBuild.BuildActions
 {
-    public class ZipFileOperation : BuildAction, IPreBuildAction, IPreBuildPerPlatformAction, IPostBuildAction, IPostBuildPerPlatformAction
+
+    public class CustomZipFileOperation : BuildAction, IPreBuildAction, IPreBuildPerPlatformAction, IPostBuildAction, IPostBuildPerPlatformAction
     {
         public string inputPath = "$BUILDPATH";
         public string outputPath = "$BUILDPATH";
@@ -22,10 +26,9 @@ namespace SuperUnityBuild.BuildActions
             if (!resolvedOutputPath.EndsWith(".zip"))
                 resolvedOutputPath += ".zip";
 
-            PerformZip(Path.GetFullPath(resolvedInputPath), Path.GetFullPath(resolvedOutputPath));
+            PerformZip(Path.GetFullPath(resolvedInputPath), Path.GetFullPath(resolvedOutputPath), platform);
         }
-
-        private void PerformZip(string inputPath, string outputPath)
+        private void PerformZip(string inputPath, string outputPath, BuildPlatform platform)
         {
             try
             {
@@ -48,14 +51,27 @@ namespace SuperUnityBuild.BuildActions
                 // Delete old file if it exists.
                 if (File.Exists(outputPath))
                     File.Delete(outputPath);
-
-                using (ZipFile zip = new ZipFile(outputPath))
+#if NET_4_6 || NETSTANDARD2_0_OR_GREATER
+        System.IO.Compression.ZipFile.CreateFromDirectory(inputPath, outputPath);
+        if (platform.platformName == "macOS")
+        {
+          var zipArchive = System.IO.Compression.ZipFile.Open(outputPath, ZipArchiveMode.Update);
+          foreach (var entry in zipArchive.Entries)
+          {
+            if (entry.FullName.Contains("Contents/MacOS"))
+              entry.ExternalAttributes = 0755;
+          }
+          zipArchive.Dispose();
+        }
+#else
+                using (Ionic.Zip.ZipFile zip = new Ionic.Zip.ZipFile(outputPath))
                 {
                     zip.ParallelDeflateThreshold = -1; // Parallel deflate is bugged in DotNetZip, so we need to disable it.
                     zip.UseZip64WhenSaving = Zip64Option.AsNecessary;
                     zip.AddDirectory(inputPath);
                     zip.Save();
                 }
+#endif
             }
             catch (Exception ex)
             {

--- a/Editor/ZipFile/ZipFileOperation.cs
+++ b/Editor/ZipFile/ZipFileOperation.cs
@@ -10,7 +10,6 @@ using Ionic.Zip;
 
 namespace SuperUnityBuild.BuildActions
 {
-
     public class ZipFileOperation : BuildAction, IPreBuildAction, IPreBuildPerPlatformAction, IPostBuildAction, IPostBuildPerPlatformAction
     {
         public string inputPath = "$BUILDPATH";
@@ -29,6 +28,7 @@ namespace SuperUnityBuild.BuildActions
 
             PerformZip(Path.GetFullPath(resolvedInputPath), Path.GetFullPath(resolvedOutputPath), platform);
         }
+
         private void PerformZip(string inputPath, string outputPath, BuildPlatform platform)
         {
             try

--- a/Editor/ZipFile/ZipFileOperation.cs
+++ b/Editor/ZipFile/ZipFileOperation.cs
@@ -10,7 +10,7 @@ using Ionic.Zip;
 namespace SuperUnityBuild.BuildActions
 {
 
-    public class CustomZipFileOperation : BuildAction, IPreBuildAction, IPreBuildPerPlatformAction, IPostBuildAction, IPostBuildPerPlatformAction
+    public class ZipFileOperation : BuildAction, IPreBuildAction, IPreBuildPerPlatformAction, IPostBuildAction, IPostBuildPerPlatformAction
     {
         public string inputPath = "$BUILDPATH";
         public string outputPath = "$BUILDPATH";

--- a/Editor/ZipFile/ZipFileOperation.cs
+++ b/Editor/ZipFile/ZipFileOperation.cs
@@ -1,6 +1,7 @@
 ﻿using SuperUnityBuild.BuildTool;
 using System;
 using System.IO;
+using UnityEngine;
 #if NET_4_6 || NETSTANDARD2_0_OR_GREATER
 using System.IO.Compression;
 #else


### PR DESCRIPTION
There is a known issue where creating a ZIP file using the ZipFileOperation action on MacOS results in a non-functional archive when opened with the MacOS default "Archive Utility." Users encounter an error: **"The application 'xxx' can’t be opened."**

![image](https://github.com/superunitybuild/buildactions/assets/18232501/25c9c4d7-d0d8-45ed-b13f-dbc3ac761a6a)

The underlying issue is that UNIX executable permissions are not retained when the ZIP file is created. Addressing this requires setting the "external attributes" in the ZIP file's metadata, a feature not supported by Ionic.Zip.

To solve this, the pull request implements ZIP file creation using System.IO.Compression.ZipArchive which allows for updating the "ExternalAttributes" to preserve the necessary permissions.

System.IO.Compression has been supported in Unity since version 2017.1 with the availability of .NET 4.6.

For further reference, please see: https://github.com/rtouk/macifyZip

